### PR TITLE
enhancement: optimized the build time and reduced it from 1.03 MB to 31KB

### DIFF
--- a/packages/ui/.npmignore
+++ b/packages/ui/.npmignore
@@ -1,0 +1,9 @@
+src/
+.storybook/
+*.stories.*
+*.test.*
+*.map
+tsconfig.json
+tsup.config.ts
+vitest.config.ts
+__tests__/

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anci/ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint 'src/**/*.{ts,tsx}' --fix",
     "check-types": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "npm-publish": "npm publish --access public"
   },
   "peerDependencies": {
     "react": ">=18.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,12 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "files": [
     "dist"
   ],

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,16 +2,20 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "declaration": true,
-    "declarationMap": true,
-    "noEmit": false,
+    "declaration": false,
+    "declarationMap": false,
+    "noEmit": true,
     "composite": false,
     "incremental": false,
     "isolatedModules": false,
-    "types": ["node"],
+    "types": ["node", "react"],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "tsup.config.ts"]
 }

--- a/packages/ui/tsup.config.ts
+++ b/packages/ui/tsup.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.stories.*',
+    '!src/**/*.test.*',
+    '!src/**/*.spec.*',
+    '!src/**/__tests__/**',
+    '!src/**/.storybook/**',
+  ],
   format: ['esm', 'cjs'],
   dts: true,
   sourcemap: true,
@@ -10,16 +18,4 @@ export default defineConfig({
   skipNodeModulesBundle: true,
   treeshake: true,
   outDir: 'dist',
-  external: [
-    // Exclude all Storybook files
-    '**/*.stories.*',
-    '**/.storybook/**',
-    '**/stories/**',
-    // Exclude test files
-    '**/__tests__/**',
-    '**/*.test.*',
-    '**/*.spec.*',
-  ],
-  // Ensure external patterns are strictly enforced
-  noExternal: [/^(?!.*\.(stories|test|spec)\.).*$/],
 });


### PR DESCRIPTION
## Why?
- The UI package build size was unnecessarily large (1.03 MB)
- Build configuration needed optimization to exclude unnecessary files
- Package exports needed proper configuration for better module resolution
- TypeScript configuration required improvements for better type safety and build performance

## What?
- Added `.npmignore` to exclude unnecessary files from the package
- Optimized `package.json` with proper exports configuration
- Updated TypeScript configuration for better type safety and build performance
- Improved `tsup.config.ts` for better tree-shaking and build optimization

## How?
1. **Package Configuration**
   - Added `.npmignore` to exclude source files, tests, and development configurations
   - Updated `package.json` with proper `exports` field for better module resolution
   - Configured `files` field to only include the `dist` directory

2. **TypeScript Configuration**
   - Updated `tsconfig.json` with stricter type checking
   - Disabled declaration maps for production builds
   - Added essential compiler options for better type safety
   - Added React types to the configuration

3. **Build Configuration**
   - Optimized `tsup.config.ts` entry points to exclude test and story files
   - Improved tree-shaking configuration
   - Removed redundant external patterns
   - Added proper source file filtering

## Demo/GIFs/Screenshots?
<img width="941" alt="Screenshot 2025-06-08 at 12 33 44 AM" src="https://github.com/user-attachments/assets/8bc61d72-ac37-48fe-8ccc-febec0f40aea" />


## Anything else?
- The changes follow modern package publishing best practices
- Improved type safety with stricter TypeScript configuration
- Better module resolution with proper exports configuration
- Reduced package size by excluding unnecessary files

## What next?
- Monitor the actual build size reduction in production
- Consider implementing bundle analysis tools (like `bundlephobia` or `size-limit`)
- Add build size checks in CI/CD pipeline
- Consider implementing code splitting for larger components